### PR TITLE
Update README.md fixing outdated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Kenny's Lisp NYC February Talk Slides are [here!](https://github.com/kennytilton
 
 Please check out the Wiki for motivation and general overview: https://github.com/kennytilton/cells/wiki
 
-No documentation other than the test suite, but ping me for help. I am starting on a port to Clojure/ClojureScript called **MatrixCLJS**, residing temporarily at [TodoFRP MatrixCLJS](https://github.com/kennytilton/todoFRP/blob/matrixjs/todo/MatrixCLJS/README.md)
+No documentation other than the test suite, but ping me for help. I am starting on a port to Clojure/ClojureScript called **MatrixCLJS**, residing temporarily at [TodoFRP MatrixCLJS](https://github.com/kennytilton/MatrixJS/blob/master/cljs/matrix/README.md)
 
 **MatrixCLJS** is pretty far along and in some ways exceeds Cells in capability and even has a benign issue fixed.
 
-There is a [pure Javascript version](https://github.com/kennytilton/todoFRP/tree/matrixjs/todo/MatrixJS) as well. 
+There is a [pure Javascript version](https://github.com/kennytilton/MatrixJS/blob/master/README.md) as well. 


### PR DESCRIPTION
To fix broken links:
- Changed link for 'TodoFRP Matrix CLJS' to https://github.com/kennytilton/MatrixJS/blob/master/cljs/matrix/README.md
- Changed link for 'pure Javascript version' to https://github.com/kennytilton/MatrixJS/blob/master/README.md